### PR TITLE
Add support for Celestica Belgite; bugs fixed

### DIFF
--- a/PSME/CMakeLists.txt
+++ b/PSME/CMakeLists.txt
@@ -143,6 +143,7 @@ ENDIF()
 ###############################################################################
 # Find packages provided by us or by system
 
+install_third_party(Nghttp2)
 install_third_party(SpdLog)
 #error( "Just for debug" )
 # will not link if not ENABLE_HTTPS: some symbols are referenced directly
@@ -191,6 +192,10 @@ if (NOT CMAKE_CROSSCOMPILING)
     install_third_party(GoogleTest)
     install_third_party(GoogleMock)
     enable_testing()
+endif()
+
+if (NOT CMAKE_CROSSCOMPILING)
+    install_third_party(Nghttp2)
 endif()
 
 # Enable sanitizers

--- a/PSME/agent/network/acc_sw/HW_NODE_CELBELGITE
+++ b/PSME/agent/network/acc_sw/HW_NODE_CELBELGITE
@@ -1,0 +1,29 @@
+# Celestica DeviceManager
+# Copyright 2021-2022 Celestica Inc.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#################################################################################
+# Support Platform type
+#################################################################################
+
+# Called by /etc/psme/C_PINFO to auto-generate /etc/psme/platform_info.conf when PSME service starts
+fans_type=("S" "S" "S" "P" "P")
+thermals_type=("S" "S" "S" "S" "C" "P" "P" "P" "P")
+psus_type=("S" "S")
+mapping=("SFP" "SFP" "SFP" "SFP" "SFP" "SFP" "SFP" "SFP")
+

--- a/PSME/agent/network/acc_sw/HW_TYPE
+++ b/PSME/agent/network/acc_sw/HW_TYPE
@@ -108,6 +108,10 @@ if [ ! -z "${HW_type}" ];then
         "x86"[-_]"64-accton"[-_]"as5835"[-_]"54t")
         . /etc/psme/HW_NODE_AS5835_54T
         ;;                
+        "x86"[-_]"64-cel"[-_]"belgite")
+        . /etc/psme/HW_NODE_CELBELGITE
+        . /etc/psme/platform/celestica/x86_64/belgite/script/power_ctl.sh
+        ;;
         "arm-accton-as4610-54")
         . /etc/psme/HW_NODE_AS4610_54T
         ;;

--- a/PSME/agent/network/acc_sw/acc_script/psme.sh
+++ b/PSME/agent/network/acc_sw/acc_script/psme.sh
@@ -69,12 +69,12 @@ update_sw_volt()
 
 set_forceoff()
 {
-    echo "NOT support."
+    set_platform_forceoff || echo "NOT support."
 }
 
 set_forcerestart()
 {
-    echo "NOT support."
+    set_platform_forcerestart || echo "NOT support."
 }
 
 get_max_fan_num()

--- a/PSME/agent/network/acc_sw/platform/celestica/x86_64/belgite/script/power_ctl.sh
+++ b/PSME/agent/network/acc_sw/platform/celestica/x86_64/belgite/script/power_ctl.sh
@@ -1,0 +1,17 @@
+CPLD_I2C_BUS=2
+CPLD_I2C_ADDR=0x32
+
+PWR_COME_CTTL_REG=0x11
+PWR_COME_OFF=0x00
+
+RST_COME_CTTL_REG=0x12
+RST_COME_OFF=0x00
+
+set_platform_forceoff()
+{    
+    i2cset -y -f $CPLD_I2C_BUS $CPLD_I2C_ADDR $PWR_COME_CTTL_REG $PWR_COME_OFF 
+}
+set_platform_forcerestart()
+{
+    i2cset -y -f $CPLD_I2C_BUS $CPLD_I2C_ADDR $RST_COME_CTTL_REG $RST_COME_OFF  
+}

--- a/PSME/cmake/FindNghttp2.cmake
+++ b/PSME/cmake/FindNghttp2.cmake
@@ -1,0 +1,19 @@
+# <license_header>
+#
+# Copyright (c) 2022-2024 Celestica Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# </license_header>
+
+find_package_local(Nghttp2 libnghttp2)

--- a/PSME/cmake/InstallNghttp2.cmake
+++ b/PSME/cmake/InstallNghttp2.cmake
@@ -1,0 +1,82 @@
+# <license_header>
+#
+# Copyright (c) 2022-2024 Celestica Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# </license_header>
+
+# check if package exists in the third_party directory
+# download and unpack otherwise
+
+
+function(install_nghttp2)
+    assure_package("libnghttp2" "1.49.0" "https://github.com/nghttp2/nghttp2/archive/refs/tags/v1.49.0.zip" "4b7b5458ae53567fc1c1936e7b0f6240")
+
+    set(ARGS)
+    list(APPEND ARGS -DCMAKE_PREFIX_PATH:PATH=${CMAKE_BINARY_DIR})
+    list(APPEND ARGS -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_BINARY_DIR})
+
+    list(APPEND ARGS -DBUILD_SHARED_LIBS:BOOL=ON)
+    list(APPEND ARGS -DBUILD_STATIC_LIBS:BOOL=OFF)
+
+    if (CMAKE_CROSSCOMPILING)
+        if (CMAKE_TOOLCHAIN_FILE AND EXISTS ${CMAKE_TOOLCHAIN_FILE})
+            list(APPEND ARGS -DCMAKE_TOOLCHAIN_FILE:FILEPATH=${CMAKE_TOOLCHAIN_FILE})
+        endif()
+
+        list(APPEND ARGS -DCMAKE_FIND_ROOT_PATH:PATH=${CMAKE_BINARY_DIR})
+    endif()
+
+    if (CMAKE_BUILD_TYPE)
+        list(APPEND ARGS -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE})
+    endif()
+
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} ${ARGS} ${source_dir}
+        WORKING_DIRECTORY ${binary_dir}
+        RESULT_VARIABLE result
+    )
+    if (NOT ${result} EQUAL 0)
+        message(FATAL_ERROR "Error occurs when configure project")
+    endif()
+
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} --build ${binary_dir} --target all -- ${BUILD_EXTRA_ARGS}
+        WORKING_DIRECTORY ${binary_dir}
+        RESULT_VARIABLE result
+    )
+    if (NOT ${result} EQUAL 0)
+        message(FATAL_ERROR "Error occurs when build project")
+    endif()
+
+    file(COPY ${binary_dir}/lib/libnghttp2.pc DESTINATION ${CMAKE_PKG_CONFIG_DIR})
+
+    file(INSTALL ${binary_dir}/lib/
+        DESTINATION ${CMAKE_BINARY_DIR}/lib
+        FILES_MATCHING PATTERN "*.so*"
+        PATTERN "CMakeFiles" EXCLUDE
+    )
+
+    file(INSTALL ${binary_dir}/lib/includes/nghttp2
+        DESTINATION ${CMAKE_BINARY_DIR}/include
+    )
+
+    file(INSTALL ${source_dir}/lib/includes/nghttp2/
+        DESTINATION ${CMAKE_BINARY_DIR}/include/nghttp2
+        FILES_MATCHING PATTERN "*.h"
+    )
+
+endfunction()
+
+install_nghttp2()

--- a/PSME/common/ecrf_pal_helper/include/ecrf_pal_helper/api/ecrf_pal_helper.hpp
+++ b/PSME/common/ecrf_pal_helper/include/ecrf_pal_helper/api/ecrf_pal_helper.hpp
@@ -439,6 +439,10 @@ public:
     int get_fan_info_by_(int fanid, Fan_Content id);
     int get_fan_num() { return m_fan_max_num; };
     int get_psu_num() { return m_psu_max_num; };
+    /* Support more than one thermal sensor in PSU */
+    int get_thermal_sen_num_in_psu() { return m_thermal_sen_num_in_psu; };
+    /* End */
+
     double get_thermal_info_by_(int thermalid, Thermal_Content id);
     int get_thermal_num() { return m_thermal_sen_max_num; };
     int get_port_info_by_(int portid, Port_Content id);
@@ -503,6 +507,11 @@ protected:
     int m_port_max_num = 0;
     int m_thermal_sen_max_num = 0;
     int m_psu_max_num = 0;
+    /* Support more than one thermal sensor in PSU */
+    int m_thermal_sen_of_psu_diff_psu_num = 0;
+    int m_thermal_sen_num_in_psu = 0;
+    /* End */
+
     int m_cpu_stepping = 0;
     int m_cpu_max_speed = 0;
     int m_cpu_total_core = 0;

--- a/PSME/common/ecrf_pal_helper/src/api/ecrf_pal_helper.cpp
+++ b/PSME/common/ecrf_pal_helper/src/api/ecrf_pal_helper.cpp
@@ -1443,8 +1443,21 @@ void Switch::get_board_info()
                 {
                     m_thermal_sen_max_num = t_rv;
                 }
+
+                /* Support more than one thermal sensor in PSU */
+                m_thermal_sen_max_num = s[0]["ecrf_pal"]["thermal_sen_max_num"].asInt();
+                if (m_thermal_sen_max_num < t_rv)
+                {
+                    m_thermal_sen_max_num = t_rv;
+                }
                 else
-                    m_thermal_sen_max_num = s[0]["ecrf_pal"]["thermal_sen_max_num"].asInt();
+                {
+                    /* t_rv = chassis thermal sensors num + PSU num
+		     * m_thermal_sen_of_psu_diff_psu_num is the difference between total PSU thermal sensors number
+                     * and total PSU number */
+                    m_thermal_sen_of_psu_diff_psu_num = m_thermal_sen_max_num - t_rv;
+                }
+                /* End */
 
                 if (get_thermal_num() > 0)
                 {
@@ -1489,6 +1502,10 @@ void Switch::get_board_info()
                 }
                 else
                     m_psu_max_num = s[0]["ecrf_pal"]["psu_max_num"].asInt();
+
+                /* Support more than one thermal sensor in PSU */
+                m_thermal_sen_num_in_psu = m_thermal_sen_of_psu_diff_psu_num / m_psu_max_num + 1;
+                /* End */
 
                 if (get_psu_num() > 0)
                 {

--- a/PSME/tools/deb_maker/install/allinone-deb/sh/prepare.sh
+++ b/PSME/tools/deb_maker/install/allinone-deb/sh/prepare.sh
@@ -42,6 +42,7 @@ cp -rf ${PSME_EC_SW_DIR}/mod_conf                       $ITEM_PATH/usr/local/bin
 cp ${PSME_EC_SW_DIR}/PrivilegeRegistry             	    $ITEM_PATH/etc/psme/RegistryFiles/PrivilegeRegistry
 cp ${PSME_EC_SW_DIR}/AcctonFirmwareUpdateRegistry       $ITEM_PATH/etc/psme/RegistryFiles/AcctonFirmwareUpdateRegistry
 cp ${PSME_EC_SW_DIR}/*                                  $ITEM_PATH/etc/psme 2>/dev/null  
+cp -rf ${PSME_EC_SW_DIR}/platform                       $ITEM_PATH/etc/psme
 
 #cp from runtime build
 cp $PSME_PROJ_PATH/bin/psme-rest-server                  $ITEM_PATH/usr/local/bin
@@ -51,6 +52,7 @@ cp $PSME_PROJ_PATH/lib/libmicrohttpd.so                  $ITEM_PATH/usr/local/li
 cp $PSME_PROJ_PATH/lib/libjsonrpccpp-server.so.999       $ITEM_PATH/usr/local/lib
 cp $PSME_PROJ_PATH/lib/libjsonrpccpp-client.so.999       $ITEM_PATH/usr/local/lib
 cp $PSME_PROJ_PATH/lib/libjsonrpccpp-common.so.999       $ITEM_PATH/usr/local/lib
+cp $PSME_PROJ_PATH/lib/libnghttp2.so.14                  $ITEM_PATH/usr/local/lib
 
 #For SONiC lib 
 cp ${PSME_EC_SW_DIR}/x_86_sonic_lib/*                   $ITEM_PATH/usr/local/lib


### PR DESCRIPTION
Add basic support for Celestica Belgite
Complement forceoff/forcerestart function for Celestica Belgite 
Add patch to support more than one thermal sensor per PSU 
Add dynamic-link library nghttp2 to support HTTP service

- CPU: Intel Denverton
- MAC: Broadcom BCM56277
- Network: 48x10/100/1000M RJ45 ports and 8xSFP+

Signed-off-by: Nicholas Wu nicwu@celestica.com
Signed-off-by: Pradchaya Phucharoen pphuchar@celestica.com
Signed-off-by: Srikanth Krishnamachary srikanth@celestica.com
Signed-off-by: Ramar N nramar@celestica.com